### PR TITLE
Fix incorrect tree command in G035.

### DIFF
--- a/G035 - Deploying services 04 ~ Monitoring stack - Part 1 - Outlining setup and arranging storage.md
+++ b/G035 - Deploying services 04 ~ Monitoring stack - Part 1 - Outlining setup and arranging storage.md
@@ -640,7 +640,7 @@ The last step regarding the storage setup is to create an extra folder serving a
 2. Check the `k3smnt` folder with `tree`.
 
     ~~~bash
-    $ tree -F /mnt/prometheus-ssd
+    $ tree -F /mnt/monitoring-ssd/
     /mnt/monitoring-ssd
     └── prometheus-data/
         ├── k3smnt/


### PR DESCRIPTION
The command should be `tree -F /mnt/monitoring-ssd/` instead of `tree -F /mnt/monitoring-ssd/`.