### PR TITLE
V2. G013. Refresh to newer software versions

### DIFF
--- a/G000 - Table Of Contents.md
+++ b/G000 - Table Of Contents.md
@@ -120,7 +120,8 @@
 
 ### [**G013** - Host hardening 07 ~ Mitigating CPU vulnerabilities](G013%20-%20Host%20hardening%2007%20~%20Mitigating%20CPU%20vulnerabilities.md#g013-host-hardening-07-mitigating-cpu-vulnerabilities)
 
-- [Checking out your CPU's vulnerabilities](G013%20-%20Host%20hardening%2007%20~%20Mitigating%20CPU%20vulnerabilities.md#checking-out-your-cpus-vulnerabilities)
+- [CPUs also have security vulnerabilities](G013%20-%20Host%20hardening%2007%20~%20Mitigating%20CPU%20vulnerabilities.md#cpus-also-have-security-vulnerabilities)
+- [Discovering your CPU's vulnerabilities](G013%20-%20Host%20hardening%2007%20~%20Mitigating%20CPU%20vulnerabilities.md#discovering-your-cpus-vulnerabilities)
 - [Applying the correct microcode package](G013%20-%20Host%20hardening%2007%20~%20Mitigating%20CPU%20vulnerabilities.md#applying-the-correct-microcode-package)
 - [Relevant system paths](G013%20-%20Host%20hardening%2007%20~%20Mitigating%20CPU%20vulnerabilities.md#relevant-system-paths)
 - [References](G013%20-%20Host%20hardening%2007%20~%20Mitigating%20CPU%20vulnerabilities.md#references)

--- a/G013 - Host hardening 07 ~ Mitigating CPU vulnerabilities.md
+++ b/G013 - Host hardening 07 ~ Mitigating CPU vulnerabilities.md
@@ -1,93 +1,117 @@
 # G013 - Host hardening 07 ~ Mitigating CPU vulnerabilities
 
-CPUs also come with bugs and, in some cases, can become security vulnerabilities. At the time of writing this, the most famous cases of such bugs are the **meltdown** and **spectre** vulnerabilities.
+- [CPUs also have security vulnerabilities](#cpus-also-have-security-vulnerabilities)
+- [Discovering your CPU's vulnerabilities](#discovering-your-cpus-vulnerabilities)
+- [Applying the correct microcode package](#applying-the-correct-microcode-package)
+- [Relevant system paths](#relevant-system-paths)
+  - [Directories](#directories)
+  - [Files](#files)
+- [References](#references)
+  - [About CPU vulnerabilities](#about-cpu-vulnerabilities)
+  - [Debian](#debian)
+- [Navigation](#navigation)
 
-## Checking out your CPU's vulnerabilities
+## CPUs also have security vulnerabilities
+
+CPUs also come with bugs and, in some cases, can become security vulnerabilities. At the time of writing this, the most famous cases of such bugs (still) are the **meltdown** and **spectre** vulnerabilities.
+
+## Discovering your CPU's vulnerabilities
 
 To check out what known vulnerabilities your CPU has, perform these steps.
 
 1. Open a shell as your administrator user, and execute the following.
 
-    ~~~bash
+    ~~~sh
     $ cat /proc/cpuinfo | grep bugs
     ~~~
 
-2. The output will be one line per core on your CPU. So, in an old four single-threaded cores Intel CPU like mine it looks like below.
+2. The output will be one line per core on your CPU. So, in the four-cores processor of my virtual machine it looks like below.
 
-    ~~~bash
-    bugs            : cpu_meltdown spectre_v1 spectre_v2 mds msbds_only
-    bugs            : cpu_meltdown spectre_v1 spectre_v2 mds msbds_only
-    bugs            : cpu_meltdown spectre_v1 spectre_v2 mds msbds_only
-    bugs            : cpu_meltdown spectre_v1 spectre_v2 mds msbds_only
+    ~~~sh
+    bugs            : cpu_meltdown spectre_v1 spectre_v2 spec_store_bypass l1tf mds swapgs itlb_multihit srbds mmio_stale_data retbleed gds bhi
+    bugs            : cpu_meltdown spectre_v1 spectre_v2 spec_store_bypass l1tf mds swapgs itlb_multihit srbds mmio_stale_data retbleed gds bhi
+    bugs            : cpu_meltdown spectre_v1 spectre_v2 spec_store_bypass l1tf mds swapgs itlb_multihit srbds mmio_stale_data retbleed gds bhi
+    bugs            : cpu_meltdown spectre_v1 spectre_v2 spec_store_bypass l1tf mds swapgs itlb_multihit srbds mmio_stale_data retbleed gds bhi
     ~~~
 
-As you may expect, the list of vulnerabilities will change depending on the CPU.
+    > [!NOTE]
+    > **VMs inherit the bugs of the real processor they run on**\
+    > The bugs listed above come from the Intel Core i7 processor running the VM where I've installed the Proxmox VE setup explained in this guide.
+
+As you may expect, the list of vulnerabilities will change depending on the CPU inspected.
 
 ## Applying the correct microcode package
 
 To mitigate these bugs, you can install the proper microcode `apt` package for your CPU: the `intel-microcode` or the `amd-microcode` one. But to do so, first you need to enable the proper `apt` sources so those packages can be downloaded in your system.
 
-1. Log in as `mgrsys`, then `cd` to `/etc/apt/sources.list.d`.
+1. Log in as `mgrsys`, then `cd` to `/etc/apt/sources.list.d`:
 
-    ~~~bash
+    ~~~sh
     $ cd /etc/apt/sources.list.d
     ~~~
 
-2. Create a new file called `debian-nonfree.list`.
+2. Create a new file called `debian-nonfree.list`:
 
-    ~~~bash
+    ~~~sh
     $ sudo touch debian-nonfree.list
     ~~~
 
-3. Edit the `debian-nonfree.list` file, filling it with the lines below.
+3. Edit the `debian-nonfree.list` file, filling it with the lines below:
 
-    ~~~bash
-    deb http://deb.debian.org/debian bullseye non-free
-    deb-src http://deb.debian.org/debian bullseye non-free
+    ~~~sh
+    deb https://deb.debian.org/debian bookworm main contrib non-free non-free-firmware
+    deb-src https://deb.debian.org/debian bookworm main contrib non-free non-free-firmware
 
-    deb http://deb.debian.org/debian-security/ bullseye-security non-free
-    deb-src http://deb.debian.org/debian-security/ bullseye-security non-free
+    deb https://security.debian.org/debian-security bookworm-security main contrib non-free non-free-firmware
+    deb-src https://security.debian.org/debian-security bookworm-security main contrib non-free non-free-firmware
 
-    deb http://deb.debian.org/debian bullseye-updates non-free
-    deb-src http://deb.debian.org/debian bullseye-updates non-free
+    deb https://deb.debian.org/debian bookworm-updates main contrib non-free non-free-firmware
+    deb-src https://deb.debian.org/debian bookworm-updates main contrib non-free non-free-firmware
     ~~~
 
-    > **BEWARE!**  
-    > This sources list is only for Debian 11 Bullseye!
+    > [!WARNING]
+    > This sources list is only for **Debian 12 (Bookworm)**!
 
-4. Save the file, update `apt` and then install the package that suits your CPU. In my case, I'll apply the `intel-microcode` package.
+4. Save the file, update `apt` and then install the package that suits your CPU. In my case, I'll apply the `intel-microcode` package:
 
-    ~~~bash
+    ~~~sh
     $ sudo apt update
     $ sudo apt install -y intel-microcode
     ~~~
 
 5. After the package's installation is done, reboot your system.
 
-    ~~~bash
+    ~~~sh
     $ sudo reboot
     ~~~
 
-> **BEWARE!**  
-> The microcode package can affect the **performance** of your CPU. Also, the microcode applied may just mitigate rather than completely fix the vulnerabilities on your CPU.
+> [!WARNING]
+> **The microcode package can affect your CPU's performance**\
+> Furthermore, the microcode applied may just mitigate rather than completely fix the vulnerabilities on your CPU.
 
 ## Relevant system paths
 
-### _Directories_
+### Directories
 
 - `/etc/apt/sources.list.d`
 - `/proc`
 
-### _Files_
+### Files
 
 - `/etc/apt/sources.list.d/debian-nonfree.list`
 - `/proc/cpuinfo`
 
 ## References
 
+### About CPU vulnerabilities
+
 - [Meltdown and Spectre](https://meltdownattack.com/)
 - [Microcode on Debian Wiki](https://wiki.debian.org/Microcode)
+
+### [Debian](https://www.debian.org/)
+
 - [Debian Wiki. SourcesList](https://wiki.debian.org/SourcesList)
+- [How do I install non-free firmware in Debian 12 (Bookworm)?](https://unix.stackexchange.com/questions/736065/how-do-i-install-non-free-firmware-in-debian-12-bookworm)
 
 ## Navigation
 


### PR DESCRIPTION
## Update of chapter G013

This update adds ToC and an opening section to G013's content. Also refresh the chapter's contents, ensuring that they correspond with the Proxmox VE version used in this update.