### PR TITLE
V2. G004. Redone refresh to newer software versions

### DIFF
--- a/G000 - Table Of Contents.md
+++ b/G000 - Table Of Contents.md
@@ -20,7 +20,7 @@
 - [The reference hardware setup](G001%20-%20Hardware%20setup.md#the-reference-hardware-setup)
 - [References](G001%20-%20Hardware%20setup.md#references)
 
-### [**G002** - Proxmox VE installation](G002%20-%20Proxmox%20VE%20installation.md#g002-proxmox-ve-installation)
+### [**G002** - Proxmox VE installation](G002%20-%20Proxmox%20VE%20installation.md)
 
 - [A procedure to install Proxmox VE in limited consumer hardware](G002%20-%20Proxmox%20VE%20installation.md#a-procedure-to-install-proxmox-ve-in-limited-consumer-hardware)
 - [System Requirements](G002%20-%20Proxmox%20VE%20installation.md#system-requirements)
@@ -29,7 +29,7 @@
 - [Connecting remotely](G002%20-%20Proxmox%20VE%20installation.md#connecting-remotely)
 - [References](G002%20-%20Proxmox%20VE%20installation.md#references)
 
-### [**G003** - Host configuration 01 ~ Apt sources, updates and extra tools](G003%20-%20Host%20configuration%2001%20~%20Apt%20sources,%20updates%20and%20extra%20tools.md#g003-host-configuration-01-apt-sources-updates-and-extra-tools)
+### [**G003** - Host configuration 01 ~ Apt sources, updates and extra tools](G003%20-%20Host%20configuration%2001%20~%20Apt%20sources,%20updates%20and%20extra%20tools.md)
 
 - [Proxmox VE 9.0 runs on Debian 13 "trixie"](G003%20-%20Host%20configuration%2001%20~%20Apt%20sources,%20updates%20and%20extra%20tools.md#proxmox-ve-90-runs-on-debian-13-trixie)
 - [Editing the apt repository sources](G003%20-%20Host%20configuration%2001%20~%20Apt%20sources,%20updates%20and%20extra%20tools.md#editing-the-apt-repository-sources)
@@ -38,15 +38,17 @@
 - [Relevant system paths](G003%20-%20Host%20configuration%2001%20~%20Apt%20sources,%20updates%20and%20extra%20tools.md#relevant-system-paths)
 - [References](G003%20-%20Host%20configuration%2001%20~%20Apt%20sources,%20updates%20and%20extra%20tools.md#references)
 
-### [**G004** - Host configuration 02 ~ UPS management with NUT](G004%20-%20Host%20configuration%2002%20~%20UPS%20management%20with%20NUT.md#g004-host-configuration-02-ups-management-with-nut)
+### [**G004** - Host configuration 02 ~ UPS management with NUT](G004%20-%20Host%20configuration%2002%20~%20UPS%20management%20with%20NUT.md)
 
-- [Connecting your UPS with your pve node using NUT](G004%20-%20Host%20configuration%2002%20~%20UPS%20management%20with%20NUT.md#connecting-your-ups-with-your-pve-node-using-nut)
-- [Executing instant commands on the UPS unit](G004%20-%20Host%20configuration%2002%20~%20UPS%20management%20with%20NUT.md#executing-instant-commands-on-the-ups-unit)
+- [Any server must be always connected to an UPS unit](G004%20-%20Host%20configuration%2002%20~%20UPS%20management%20with%20NUT.md#any-server-must-be-always-connected-to-an-ups-unit)
+- [Connecting your UPS with your PVE node using NUT](G004%20-%20Host%20configuration%2002%20~%20UPS%20management%20with%20NUT.md#connecting-your-ups-with-your-pve-node-using-nut)
+- [Checking the NUT logs](G004%20-%20Host%20configuration%2002%20~%20UPS%20management%20with%20NUT.md#checking-the-nut-logs)
+- [Executing instant commands on your UPS unit](G004%20-%20Host%20configuration%2002%20~%20UPS%20management%20with%20NUT.md#executing-instant-commands-on-your-ups-unit)
 - [Other possibilities with NUT](G004%20-%20Host%20configuration%2002%20~%20UPS%20management%20with%20NUT.md#other-possibilities-with-nut)
 - [Relevant system paths](G004%20-%20Host%20configuration%2002%20~%20UPS%20management%20with%20NUT.md#relevant-system-paths)
 - [References](G004%20-%20Host%20configuration%2002%20~%20UPS%20management%20with%20NUT.md#references)
 
-### [**G005** - Host configuration 03 ~ LVM storage](G005%20-%20Host%20configuration%2003%20~%20LVM%20storage.md#g005-host-configuration-03-lvm-storage)
+### [**G005** - Host configuration 03 ~ LVM storage](G005%20-%20Host%20configuration%2003%20~%20LVM%20storage.md)
 
 - [Your Proxmox VE server's storage needs to be reorganized](G005%20-%20Host%20configuration%2003%20~%20LVM%20storage.md#your-proxmox-ve-servers-storage-needs-to-be-reorganized)
 - [Initial filesystem configuration (**PVE web console**)](G005%20-%20Host%20configuration%2003%20~%20LVM%20storage.md#initial-filesystem-configuration-pve-web-console)
@@ -65,7 +67,7 @@
 - [Relevant system paths](G006%20-%20Host%20configuration%2004%20~%20Removing%20Proxmox's%20subscription%20warning.md#relevant-system-paths)
 - [References](G006%20-%20Host%20configuration%2004%20~%20Removing%20Proxmox's%20subscription%20warning.md#references)
 
-### [**G007** - Host hardening 01 ~ TFA authentication](G007%20-%20Host%20hardening%2001%20~%20TFA%20authentication.md#g007-host-hardening-01-tfa-authentication)
+### [**G007** - Host hardening 01 ~ TFA authentication](G007%20-%20Host%20hardening%2001%20~%20TFA%20authentication.md)
 
 - [Enable Two Factor Authentication in your PVE system](G007%20-%20Host%20hardening%2001%20~%20TFA%20authentication.md#enable-two-factor-authentication-in-your-pve-system)
 - [Enabling TFA for SSH access](G007%20-%20Host%20hardening%2001%20~%20TFA%20authentication.md#enabling-tfa-for-ssh-access)

--- a/G004 - Host configuration 02 ~ UPS management with NUT.md
+++ b/G004 - Host configuration 02 ~ UPS management with NUT.md
@@ -1,8 +1,9 @@
 # G004 - Host configuration 02 ~ UPS management with NUT
 
 - [Any server must be always connected to an UPS unit](#any-server-must-be-always-connected-to-an-ups-unit)
-- [Connecting your UPS with your pve node using NUT](#connecting-your-ups-with-your-pve-node-using-nut)
-- [Executing instant commands on the UPS unit](#executing-instant-commands-on-the-ups-unit)
+- [Connecting your UPS with your PVE node using NUT](#connecting-your-ups-with-your-pve-node-using-nut)
+- [Checking the NUT logs](#checking-the-nut-logs)
+- [Executing instant commands on your UPS unit](#executing-instant-commands-on-your-ups-unit)
 - [Other possibilities with NUT](#other-possibilities-with-nut)
 - [Relevant system paths](#relevant-system-paths)
   - [Directories](#directories)
@@ -10,53 +11,58 @@
 - [References](#references)
   - [Network UPS Tools (NUT)](#network-ups-tools-nut)
   - [Related NUT contents](#related-nut-contents)
+  - [About UPS units](#about-ups-units)
 - [Navigation](#navigation)
 
 ## Any server must be always connected to an UPS unit
 
-You really need to protect your server from electrical surges, power cuts or outages. Here we'll assume that you already have one UPS plugged by USB to your computer.
+You really need to protect your server from electrical surges, power cuts or outages. Here we'll assume that you already have one UPS unit plugged by USB to your Proxmox VE server.
 
-The program we're going to use is a generic package called **NUT (Network UPS Tool)**, although be aware that your UPS brand may already have their own particular software for UPS management (like in the case of **APC** and its related `apcupsd` tool for Linux systems).
+In this chapter you'll learn how to make your PVE node monitor the UPS unit with a generic package called **NUT (Network UPS Tool)**. However, be aware that your UPS unit's brand may already have its own particular software for UPS management.
 
 > [!IMPORTANT]
 > **NUT may not support your concrete UPS unit**\
-> Still, it may have compatible drivers for your UPS brand. Check on the [NUT hardware compatibility list](https://networkupstools.org/stable-hcl.html) to verify if your brand or model line has compatible drivers there.
+> Still, it may have compatible drivers for your UPS unit's brand. Check in the [NUT hardware compatibility list](https://networkupstools.org/stable-hcl.html) to verify if your brand or model line has compatible drivers there.
 
-## Connecting your UPS with your pve node using NUT
+## Connecting your UPS with your PVE node using NUT
 
-In this guide, I'll work with my _APC Back-UPS_ unit. This model (and similar ones) comes with a **special USB cable** to connect the UPS with any computer. If your UPS doesn't have this cable, **you won't be able to proceed with the instructions explained below**.
+In this chapter, I'll work with my _Eaton 3S700D_ UPS unit. This model (and similar ones) comes with a **USB 2.0 cable** to connect the UPS unit with any computer.
 
-Assuming your UPS unit has the required USB cable, here's how to proceed with its configuration in your server.
+> [!WARNING]
+> If your UPS unit does not come with a USB cable, **you won't be able to proceed with the instructions explained below**.
 
-1. First, check the following.
-    - Your server is plugged in one of your UPS's _protected_ sockets.
-    - You have your UPS connected with its special cable to an USB plug in your server.
+Assuming your UPS unit has the required USB cable, here's how to proceed with its configuration in your server:
+
+1. First, check the following:
+
+    - Your server is plugged in one of your UPS's _battery-protected_ sockets.
+    - You have your UPS connected with its USB cable to an USB plug in your server.
     - The UPS unit is _on_. Obviously, if it weren't, you wouldn't be able to switch your server on.
 
-2. With your Proxmox VE server running, get into the `pve` node through a `root` shell and execute the `lsusb` command.
+2. With your Proxmox VE server running, get into the `pve` node through a `root` shell and execute the `lsusb` command:
 
-    ~~~bash
+    ~~~sh
     $ lsusb
-    Bus 002 Device 002: ID 0bc2:3330 Seagate RSS LLC Raptor 3.5" USB 3.0
-    Bus 002 Device 001: ID 1d6b:0003 Linux Foundation 3.0 root hub
-    Bus 001 Device 003: ID 0bda:0129 Realtek Semiconductor Corp. RTS5129 Card Reader Controller
-    Bus 001 Device 005: ID 051d:0002 American Power Conversion Uninterruptible Power Supply
-    Bus 001 Device 004: ID 046d:c52b Logitech, Inc. Unifying Receiver
-    Bus 001 Device 002: ID 05e3:0610 Genesys Logic, Inc. Hub
     Bus 001 Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub
+    Bus 001 Device 003: ID 05e3:0608 Genesys Logic, Inc. Hub
+    Bus 001 Device 004: ID 0bda:0129 Realtek Semiconductor Corp. RTS5129 Card Reader Controller
+    Bus 001 Device 005: ID 046d:c52b Logitech, Inc. Unifying Receiver
+    Bus 001 Device 006: ID 0463:ffff MGE UPS Systems UPS
+    Bus 002 Device 001: ID 1d6b:0003 Linux Foundation 3.0 root hub
+    Bus 002 Device 002: ID 152d:0578 JMicron Technology Corp. / JMicron USA Technology Corp. JMS578 SATA 6Gb/s
     ~~~
 
-    The `lsusb` gives you a list of the USB devices currently connected to your physical server. Please notice how my _APC Back-UPS_ unit is listed in the `Bus 001 Device 005` line, confirming the correct connection of the unit to the `pve` node.
+    The `lsusb` gives you a list of the USB devices currently connected to your physical server. Please notice how my _Eaton 3S700D_ UPS unit is listed in the `Bus 001 Device 006` line with the rather misleading name `MGE UPS Systems UPS`, confirming the correct connection of the unit to the `pve` node.
 
-3. Now you need to install the **NUT** software package.
+3. Now you need to install the **NUT** software package:
 
-    ~~~bash
+    ~~~sh
     $ apt install -y nut
     ~~~
 
-4. You need to configure NUT properly so it can manage your UPS unit. There are several files to change, let's start editing `/etc/nut/nut.conf`. But before you change it, first make a backup of it.
+4. You need to configure NUT properly so it can manage your UPS unit. There are several files to change, let's start editing `/etc/nut/nut.conf`. But before you change it, first make a backup of it:
 
-    ~~~bash
+    ~~~sh
     $ cd /etc/nut
     $ cp nut.conf nut.conf.orig
     ~~~
@@ -73,56 +79,75 @@ Assuming your UPS unit has the required USB cable, here's how to proceed with it
     MODE=standalone
     ~~~
 
-    By putting `standalone` you're enabling NUT to work in local mode or, in other words, it will "worry" only about your `pve` node. Please check the comments in the `nut.conf` to have a better idea of which are the modes that NUT supports.
+    By setting the `standalone` mode you're enabling NUT to work in local mode or, in other words, it will "worry" only about your `pve` node.
 
-5. You need to tell NUT about the UPS unit connected to your system. To do that, you must edit the file `/etc/nut/ups.conf`, so make a backup of it.
+    > [!NOTE]
+    > Check the comments in the `nut.conf` to have a better idea of which are the modes that NUT supports.
 
-    ~~~bash
+5. You need to tell NUT about the UPS unit connected to your system. To do that, you must edit the file `/etc/nut/ups.conf`, so make a backup of it:
+
+    ~~~sh
     $ cp ups.conf ups.conf.orig
     ~~~
 
     Then, **append** the following parameters to the `ups.conf` file, although with values fitting for your UPS unit.
 
     ~~~properties
-    [apc]
-        driver = usbhid-ups
-        port = auto
-        desc = "APC Back-UPS ES 700"
+    [eaton]
+      driver = usbhid-ups
+      port = auto
+      desc = "Eaton 3S700D"
      ~~~
 
     I'll explain the parameters above:
 
-    - `[apc]`: this is the name that will identify your UPS unit in NUT. This can be any string of characters, but **without spaces**. It's recommended you type something there that truly identifies your UPS in a clear manner.
+    - `[eaton]`\
+      This is the name that will identify your UPS unit in NUT. This can be any string of characters, but **without spaces**. It's recommended you type something there that truly identifies your UPS in a clear manner.
 
-    - `driver`: here you indicate NUT how to connect to your UPS unit. For UPS units with their data port plugged in a USB, the correct value is `usbhid-ups`.
+    - `driver`\
+      Here you indicate NUT how to connect to your UPS unit. For UPS units with their data port plugged in a USB, the correct value is `usbhid-ups`.
 
-    - `port`: for an USB connection this has to be left to `auto`.
+    - `port`\
+      For an USB connection this has to be left to `auto`.
 
-    - `desc`: this is just a description string in which you can type the full name and model of your UPS unit, or anything else you might prefer.
+    - `desc`\
+      This is just a descriptive string where you can type the full name and model of your UPS unit, or anything else you might prefer.
 
-6. At this point, we can check if NUT can start its driver and detect your UPS unit properly.
+6. At this point, we can check if NUT can start its driver and detect your UPS unit properly:
 
-    ~~~bash
+    ~~~sh
     $ upsdrvctl start
-    Network UPS Tools - UPS driver controller 2.8.0
-    Network UPS Tools - Generic HID driver 0.47 (2.8.0)
-    USB communication driver (libusb 1.0) 0.43
-    Using subdriver: APC HID 0.98
+    Network UPS Tools - UPS driver controller 2.8.1
+    Network UPS Tools - Generic HID driver 0.52 (2.8.1)
+    USB communication driver (libusb 1.0) 0.46
+    Using subdriver: MGE HID 1.46
     ~~~
 
-    The command tells you what components it's using and, in the last line, also indicates you what driver NUT used to connect to your particular UPS. In this guide's example, you can see it's using the correct APC "subdriver".
+    The command tells you what components it's using and, in the last line, also indicates you what driver NUT used to connect to your particular UPS. In this guide's example, you can see it's using the correct MGE "subdriver".
+
+    On the other hand, if you get the following warnings:
+
+    ~~~sh
+    libusb1: Could not open any HID devices: insufficient permissions on everything
+    No matching HID UPS found
+    upsnotify: notify about state 4 with libsystemd: was requested, but not running as a service unit now, will not spam more about it
+    upsnotify: failed to notify about state 4: no notification tech defined, will not spam more about it
+    Driver failed to start (exit status=1)
+    ~~~
+
+    Just reboot your Proxmox VE server and try the `upsdrvctl start` command again, it should run fine this time.
 
     > [!NOTE]
     > **Don't worry if you get a "Duplicate driver" warning**\
     > In the output of the `upsdrvctl start` command you may get a warning like this one:
     >
-    > `Duplicate driver instance detected (PID file /run/nut/usbhid-ups-apc.pid exists)! Terminating other driver!`
+    > `Duplicate driver instance detected (PID file /run/nut/usbhid-ups-eaton.pid exists)! Terminating other driver!`
     >
     > It seems that NUT had already created automatically a driver for my UPS unit in the moment I had configured it in the `ups.conf` file. This is not an issue at this point, and NUT itself takes care of this duplicity.
 
-7. Next, let's configure the NUT daemon, so edit the file `/etc/nut/upsd.conf`. Again, make a backup first.
+7. Next, let's configure the NUT daemon, so edit the file `/etc/nut/upsd.conf`. Again, make a backup first:
 
-    ~~~bash
+    ~~~sh
     $ cp upsd.conf upsd.conf.orig
     ~~~
 
@@ -136,18 +161,18 @@ Assuming your UPS unit has the required USB cable, here's how to proceed with it
 
     The `LISTEN` lines declares on which ports the `upsd` daemon will listen, and provides a basic access control mechanism. Uncomment the IPv6 line when you use this protocol in your network setup.
 
-8. In NUT there are also users, which are **NOT** the same ones as in the `passwd` file of your `pve` node. At this point, you'll require two user: 
+8. In NUT there are also users, which are **NOT** the same ones as in the `passwd` file of your `pve` node. At this point, you'll require two user:
 
     - One for the NUT monitor agent (`upsmon`)
     - Other for acting as a NUT ups administrator(`upsadmin`).
 
-    To add them, you must edit the file `/etc/nut/upsd.users`. First, back it up.
+    To add them, you must edit the file `/etc/nut/upsd.users`. First, back it up:
 
-    ~~~bash
+    ~~~sh
     $ cp upsd.users upsd.users.orig
     ~~~
 
-    Then, **append** to `upsd.users` the following configuration block.
+    Then, **append** to `upsd.users` the following configuration block:
 
     ~~~properties
     [upsmon]
@@ -162,22 +187,27 @@ Assuming your UPS unit has the required USB cable, here's how to proceed with it
 
     The parameters in the lines above mean the following.
 
-    - `[upsmon]`/`[upsadm]` : this is the user's name. It can be any string, **but with no spaces**.
+    - `[upsmon]`/`[upsadm]`\
+      This is the NUT user's name. It can be any string, **but with no spaces**.
 
-    - `password` : the user's password. Please bear in mind that this is an **unencrypted** configuration file, be careful with who can access it.
+    - `password`\
+      The NUT user's password. Please bear in mind that this is an **unencrypted** configuration file, be careful with who can access it.
 
-    - `upsmon primary` : roughly speaking, this line says the user is from a machine directly connected to the UPS unit, and that NUT should be run with high privileges there.
+    - `upsmon primary`\
+      Roughly speaking, this line means that the NUT user is from a machine directly connected to the UPS unit, and that NUT should be run with high privileges there.
   
       > [!NOTE]
       > The UPS primary and secondary types are further explained [in the NUT `upsmon` man documentation](https://networkupstools.org/docs/man/upsmon.html), in the **UPS types** section.
 
-    - `actions = SET` : allows the user to set values on the managed UPS unit.
+    - `actions = SET`\
+      Allows the NUT user to set values on the managed UPS unit.
 
-    - `instcmds = ALL` : allows the user to execute all available instant commands supported by the managed UPS unit.
+    - `instcmds = ALL`\
+      Allows the NUT user to execute all available instant commands supported by the managed UPS unit.
 
-9. Finally, you need to configure the NUT monitoring service that watches over the UPS unit. The configuration file you have to edit is `/etc/nut/upsmon.conf`, so back it up.
+9. Finally, you need to configure the NUT monitoring service that watches over the UPS unit. The configuration file you have to edit is `/etc/nut/upsmon.conf`, so back it up:
 
-    ~~~bash
+    ~~~sh
     $ cp upsmon.conf upsmon.conf.orig
     ~~~
 
@@ -205,7 +235,22 @@ Assuming your UPS unit has the required USB cable, here's how to proceed with it
         #
         # upsmon runs this command when the system needs to be brought down.
         #
-        # This should work just about everywhere ... if it doesn't, well, change it.
+        # This should work just about everywhere ... if it doesn't, well, change it,
+        # perhaps to a more complicated custom script.
+        #
+        # Note that while you experiment with the initial setup and want to test how
+        # your configuration reacts to power state changes and ultimately when power
+        # is reported to go critical, but do not want your system to actually turn
+        # off, consider setting the SHUTDOWNCMD temporarily to do something benign -
+        # such as posting a message with 'logger' or 'wall' or 'mailx'. Do be careful
+        # to plug the UPS back into the wall in a timely fashion.
+        #
+        # For Windows setup use something like:
+        # SHUTDOWNCMD "C:\\WINDOWS\\system32\\shutdown.exe -s -t 0"
+        # If you have command line using space character you have to add double quote to them, like this:
+        # SHUTDOWNCMD "\"C:\\Program Files\\some command.bat\" -first_arg -second_arg"
+        # Or use the old DOS 8.3 file name, like this:
+        # SHUTDOWNCMD "C:\\PROGRA~1\\SOMECO~1.bat -first_arg -second_arg"
 
         #SHUTDOWNCMD "/sbin/shutdown -h +0"
         ~~~
@@ -216,7 +261,7 @@ Assuming your UPS unit has the required USB cable, here's how to proceed with it
         # --------------------------------------------------------------------------
         # Customized settings
 
-        MONITOR apc@localhost 1 upsmon s3c4R3_p4sSw0rD! primary
+        MONITOR eaton@localhost 1 upsmon s3c4R3_p4sSw0rD! primary
         SHUTDOWNCMD "logger -t upsmon.conf \"SHUTDOWNCMD calling /sbin/shutdown to shut down system\" ; /sbin/shutdown -h +0"
 
         NOTIFYMSG ONLINE "UPS %s: On line power."
@@ -244,21 +289,26 @@ Assuming your UPS unit has the required USB cable, here's how to proceed with it
         RBWARNTIME 7200 # 2 hours
         ~~~
 
-    Here's an explanation for the parameters shown above:
+    Here's an explanation for all the added parameters in the configuration snippet:
 
-    - **`MONITOR`** : this is the line where you must type the name you gave to your UPS unit (`apc` in the example), the username (`upsmon`) and your NUT user's password (`s3c4R3_p4sSw0rD!`). The number `1` indicates the number of power supplies feeding your system through the connected UPS.
+    - `MONITOR`\
+      This is the line where you must specify your UPS unit (`eaton@localhost`), the username (`upsmon`) and your NUT user's password (`s3c4R3_p4sSw0rD!`). The number `1` indicates the number of power supplies feeding your system through the connected UPS.
 
-    - **`SHUTDOWN`** : declares the command that is to be used to shut down the host. In the line shown above, it's prepared to write a log before it executes the system's shut down.
+    - `SHUTDOWNCMD`\
+      Declares the command to be used to shut down the host. In the line shown in the snippet, the command is prepared to write a log before it executes the system's shut down.
 
-    - **`NOTIFYMSG`** : each of these lines are assigning a text message to each NOTIFY event. Within each message, the marker `%s` is replaced by the **name of the UPS** which has produced this event. `upsmon` passes this message to program wall to notify the system administrator of the event.
+    - `NOTIFYMSG`\
+      Each of these lines are assigning a text message to each NOTIFY event. Within each message, the marker `%s` is replaced by the **name of the UPS unit** producing the event. `upsmon` passes this message to program wall to notify the system administrator of the event.
 
-    - **`NOTIFYFLAG`** : each line declare what is to be done at each `NOTIFY` event. Up to three flags can be specified for each event. In the example, all events will be registered in the host's `/var/log/syslog` log file.
+    - `NOTIFYFLAG`\
+      Each line declare what is to be done at each `NOTIFY` event. Up to three flags can be specified for each event. In the example, all events will be registered in the host's `/var/log/syslog` log file.
 
-    - **`RBWARNTIME`** : when an UPS says it needs to have its battery replaced, `upsmon` will generate a `NOTIFY_REPLBATT` event. This line says that this warning will be repeated every this many **seconds**.
+    - `RBWARNTIME`\
+      When an UPS unit says it needs to have its battery replaced, `upsmon` will generate a `NOTIFY_REPLBATT` event. This parameter means that this warning will be repeated every this many **seconds**.
 
 10. Before you can try the configuration, restart the NUT-related services to be sure that they load with the right parameters.
 
-    ~~~bash
+    ~~~sh
     $ systemctl restart nut-client.service nut-server.service
     ~~~
 
@@ -266,87 +316,112 @@ Assuming your UPS unit has the required USB cable, here's how to proceed with it
 
 11. Check if the NUT services are working properly with your UPS unit.
 
-    - `upscmd -l upsname`: this will list you the instant commands supported by the UPS unit named `upsname` (replace this with the name you gave to your UPS back in point 5). Below you can see its output with my UPS unit.
+    - `upscmd -l upsunitname`\
+      Lists the instant commands supported by the UPS unit named `upsunitname` (replace the placeholder string with the name you gave to your UPS back in point 5). Below you can see its output with this guide's UPS unit:
 
-        ~~~bash
-        $ upscmd -l apc
-        Instant commands supported on UPS [apc]:
+        ~~~sh
+        $ upscmd -l eaton
+        Instant commands supported on UPS [eaton]:
 
         beeper.disable - Disable the UPS beeper
         beeper.enable - Enable the UPS beeper
         beeper.mute - Temporarily mute the UPS beeper
         beeper.off - Obsolete (use beeper.disable or beeper.mute)
         beeper.on - Obsolete (use beeper.enable)
+        driver.killpower - Tell the driver daemon to initiate UPS shutdown; should be unlocked with driver.flag.allow_killpower option or variable setting
+        driver.reload - Reload running driver configuration from the file system (only works for changes in some options)
+        driver.reload-or-error - Reload running driver configuration from the file system (only works for changes in some options); return an error if something changed and could not be applied live (so the caller can restart it with new options)
+        driver.reload-or-exit - Reload running driver configuration from the file system (only works for changes in some options); exit the running driver if something changed and could not be applied live (so service management framework can restart it with new options)
         load.off - Turn off the load immediately
         load.off.delay - Turn off the load with a delay (seconds)
-        shutdown.reboot - Shut down the load briefly while rebooting the UPS
+        load.on - Turn on the load immediately
+        load.on.delay - Turn on the load with a delay (seconds)
+        shutdown.return - Turn off the load and return when power is back
+        shutdown.stayoff - Turn off the load and remain off
         shutdown.stop - Stop a shutdown in progress
-        test.panel.start - Start testing the UPS panel
-        test.panel.stop - Stop a UPS panel test
         ~~~
 
-    - `upsc upsname`: this returns the statistics of the UPS unit specified as `upsname` (again, here you would put your own UPS unit's name). See below the output it returns in my system.
+    - `upsc upsunitname`\
+      Returns the statistics from the UPS unit specified as `upsunitname` (again, replace this string with your own UPS unit's name). See below the output this commands returns for this guide's reference hardware:
 
-        ~~~bash
-        $ upsc apc
+        ~~~sh
+        $ upsc eaton
         Init SSL without certificate database
         battery.charge: 100
-        battery.charge.low: 10
-        battery.charge.warning: 50
-        battery.date: not set
-        battery.mfr.date: 2018/04/22
-        battery.runtime: 2250
-        battery.runtime.low: 120
+        battery.charge.low: 20
+        battery.runtime: 3840
         battery.type: PbAc
-        battery.voltage: 13.7
-        battery.voltage.nominal: 12.0
-        device.mfr: APC
-        device.model: Back-UPS ES 700G
-        device.serial: 5B1816T44974  
+        device.mfr: EATON
+        device.model: Eaton 3S 700
+        device.serial: Blank
         device.type: ups
+        driver.debug: 0
+        driver.flag.allow_killpower: 0
         driver.name: usbhid-ups
         driver.parameter.pollfreq: 30
         driver.parameter.pollinterval: 2
         driver.parameter.port: auto
         driver.parameter.synchronous: auto
-        driver.version: 2.8.0
-        driver.version.data: APC HID 0.98
-        driver.version.internal: 0.47
-        driver.version.usb: libusb-1.0.26 (API: 0x1000109)
-        input.sensitivity: low
-        input.transfer.high: 266
-        input.transfer.low: 180
-        input.voltage: 230.0
-        input.voltage.nominal: 230
-        ups.beeper.status: disabled
+        driver.state: quiet
+        driver.version: 2.8.1
+        driver.version.data: MGE HID 1.46
+        driver.version.internal: 0.52
+        driver.version.usb: libusb-1.0.28 (API: 0x100010a)
+        input.transfer.high: 264
+        input.transfer.low: 184
+        outlet.1.desc: PowerShare Outlet 1
+        outlet.1.id: 1
+        outlet.1.status: on
+        outlet.1.switchable: no
+        outlet.desc: Main Outlet
+        outlet.id: 0
+        outlet.switchable: yes
+        output.frequency.nominal: 50
+        output.voltage: 230.0
+        output.voltage.nominal: 230
+        ups.beeper.status: enabled
         ups.delay.shutdown: 20
-        ups.firmware: 871.O4 .I
-        ups.firmware.aux: O4 
-        ups.load: 1
-        ups.mfr: APC
-        ups.mfr.date: 2018/04/22
-        ups.model: Back-UPS ES 700G
-        ups.productid: 0002
-        ups.serial: 5B1816T44974  
+        ups.delay.start: 30
+        ups.firmware: 02.08.0010
+        ups.load: 4
+        ups.mfr: EATON
+        ups.model: Eaton 3S 700
+        ups.power.nominal: 700
+        ups.productid: ffff
+        ups.realpower: 22
+        ups.serial: Blank
         ups.status: OL
-        ups.timer.reboot: 0
         ups.timer.shutdown: -1
-        ups.vendorid: 051d
+        ups.timer.start: -1
+        ups.type: offline / line interactive
+        ups.vendorid: 0463
         ~~~
 
-> [!IMPORTANT]
-> Don't forget to check the `/var/log/syslog` file to detect any problems with the NUT services!
+## Checking the NUT logs
 
-## Executing instant commands on the UPS unit
+NUT's services write logs in the journal of the Proxmox VE system. Look out for them with the `journalctl` command:
 
-To execute the so called **instant commands** on your UPS unit, you have to use the command `upscmd` with your **NUT administrator user** defined previously. A safe way to test this is by disabling and enabling the beeper usually embedded in any UPS.
+- `nut-server` log entries from the NUT server.
+- `nut-monitor` log entries from the NUT monitor.
+- `upsd` log entries from the UPS daemon.
 
-~~~bash
-$ upscmd apc beeper.disable
+Remember to check them out, specially when you have created or modified your NUT configuration. For instance, if NUT cannot connect with your UPS unit, you'll see in your PVE system's journal warning logs from the NUT monitor:
+
+~~~sh
+Aug 26 10:53:52 pve nut-monitor[6684]: UPS eaton@localhost: Not available.
+Aug 26 10:53:57 pve nut-monitor[6684]: Poll UPS [eaton@localhost] failed -  Poll UPS [eaton@localhost] failed - [eaton] does not exist on server localhost
+~~~
+
+## Executing instant commands on your UPS unit
+
+To execute the so called **instant commands** on your UPS unit (wich you can get them with `upscmd -l upsunitname`), you have to use the command `upscmd` with your **NUT administrator user** [defined in the previous section](#connecting-your-ups-with-your-pve-node-using-nut). A safe way to test this is by disabling and enabling the beeper usually embedded in any UPS:
+
+~~~sh
+$ upscmd eaton beeper.disable
 Username (root): upsadm
 Password:
 OK
-$ upscmd apc beeper.enable
+$ upscmd eaton beeper.enable
 Username (root): upsadm
 Password:
 OK
@@ -354,19 +429,19 @@ OK
 
 You can also execute the whole `upscmd` command in just one line:
 
-~~~bash
-$ upscmd -u upsadm -p D1Ff3rEnT_s3c4R3_p4sSw0rD! apc beeper.disable
+~~~sh
+$ upscmd -u upsadm -p D1Ff3rEnT_s3c4R3_p4sSw0rD! eaton beeper.disable
 ~~~
 
 > [!WARNING]
 > **Use this one-line format only for task automation with shell scripts**\
-> Do not execute the `upscmd` with the password in your normal shell, to avoid exposing your password in the shell history (the `.bash_history` text file in bash shells).
+> Do not execute the `upscmd` with the password in your normal shell, to avoid exposing your password in your user's shell history (the `.bash_history` text file in bash shells).
 
 Also, remember that:
 
 1. You'll have to check out first with `upscmd -l upsunitname` which are the instant commands supported by your UPS unit.
 
-2. The NUT software doesn't known if the instant command has really been executed on the UPS, it only sees what the UPS unit is answering back in response to the command's request.
+2. The NUT software does not known if the instant command has really been executed on the UPS unit, it only sees what the UPS unit is answering back in response to the command's request.
 
 ## Other possibilities with NUT
 
@@ -397,15 +472,14 @@ If you feel curious about what else you can do with NUT, there's a pdf document 
 
 ### [Network UPS Tools (NUT)](https://networkupstools.org/)
 
-- [NUT Hardware compatibility list](https://networkupstools.org/stable-hcl.html)
-- [NUT User manual (chunked)](https://networkupstools.org/docs/user-manual.chunked/index.html)
-- [NUT config examples document on GitHub](https://github.com/networkupstools/ConfigExamples/releases/tag/book-3.0-20230319-nut-2.8.0)
+- [Hardware compatibility list](https://networkupstools.org/stable-hcl.html)
+- [User manual](https://networkupstools.org/docs/user-manual.chunked/index.html)
+- [Config Examples book (version 3.0)](https://github.com/networkupstools/ConfigExamples/releases/tag/book-3.0-20230319-nut-2.8.0)
 - [Man for `upsmon`](https://networkupstools.org/docs/man/upsmon.html)
 
 ### Related NUT contents
 
-- [NUT documentation and scripts](http://rogerprice.org/NUT/)
-- [Monitorización de un SAI con GNU/Debian Linux](http://index-of.co.uk/SISTEMAS-OPERATIVOS/NUT%20Debian%20UPS%20Monitor.pdf) (in Spanish)
+- [NUT Configuration Examples](http://rogerprice.org/NUT/)
 - [Instalar y configurar NUT por SNMP](https://blog.ichasco.com/instalar-y-configurar-nut-por-snmp/) (in Spanish)
 - [Monitoring a UPS with nut on Debian or Ubuntu Linux](https://blog.shadypixel.com/monitoring-a-ups-with-nut-on-debian-or-ubuntu-linux/)
 - [Can't get upsmon service started to monitor (and respond to) remote UPS](https://serverfault.com/questions/865147/cant-get-upsmon-service-started-to-monitor-and-respond-to-remote-ups)
@@ -413,6 +487,9 @@ If you feel curious about what else you can do with NUT, there's a pdf document 
 - [HOWTO: Configure A UPS on Proxmox 5.x](https://diyblindguy.com/howto-configure-ups-on-proxmox/)
 - [UPS Server on Raspberry Pi](https://www.reddit.com/r/homelab/comments/5ssb5h/ups_server_on_raspberry_pi/)
 - [Configuring NUT for the Eaton 3S UPS on Ubuntu Linux](https://srackham.wordpress.com/2013/02/27/configuring-nut-for-the-eaton-3s-ups-on-ubuntu-linux/)
+
+### About UPS units
+
 - [UPS HowTo](https://tldp.org/HOWTO/UPS-HOWTO/)
 
 ## Navigation


### PR DESCRIPTION
## Another update of chapter G004

This updates the content of the chapter G004 so it uses a different UPS unit as reference to explain the NUT-based procedures. Also updates the shell snippets and cleans up dead reference links, plus adds a new introductory section and updates the main ToC accordingly.